### PR TITLE
fixed invalid hash

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -181,11 +181,7 @@ AddEventHandler('esx_vehicleshop:buyVehicle', function(vehicleCode)
         return
     end
 
-    local hash = vehicle.hash or -1
-
-    if (hash == -1) then
-        hash = GetHashKey(vehicle.code)
-    end
+    hash = GetHashKey(vehicle.code)
 
     local price = vehicle.price or 0
 


### PR DESCRIPTION
script was adding car hash code wrong into DB and causing some garage scripts to show invalid car. It was like "model":-"1809822327" which is not the right way.